### PR TITLE
Increased delay on toast for login page for slow connections 

### DIFF
--- a/client/src/components/Modal/TaskModal.js
+++ b/client/src/components/Modal/TaskModal.js
@@ -8,7 +8,7 @@ function TaskModal({ onHide, task }) {
     <>
       <Modal show={true} onHide={onHide}>
         <Modal.Header closeButton>
-          <Modal.Title placeholder>{task.title}</Modal.Title>
+          <Modal.Title>{task.title}</Modal.Title>
         </Modal.Header>
         <Modal.Body>{task.textBody}</Modal.Body>
         <Modal.Footer>

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -21,7 +21,7 @@ function Login() {
   const { isLoggedIn, login } = useAuth();
   const history = useHistory();
 
-  const notify = () => toast.warn("Incorrect Username or Password!", { delay: 1000 });
+  const notify = () => toast.warn("Incorrect Username or Password!", { delay: 10000 });
 
   if (isLoggedIn) {
     return <Redirect to="/" />;


### PR DESCRIPTION
Increased delay on toast warning "incorrect username or password" from 1 second to 10 seconds because it was throwing the error when Heroku booted up.